### PR TITLE
Use shared PolliLib default client and dynamic referrer

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,8 @@
             const attrRef = cur && cur.getAttribute('data-referrer');
             let base = window.location.origin;
             if (attrRef) {
-              try { base = new URL(attrRef).origin; } catch {}
+              // Support values missing protocol by resolving against window.location.origin
+              try { base = new URL(attrRef, window.location.origin).origin; } catch {}
             }
             const referrer = base.endsWith('/') ? base : base + '/';
             window.polliLib.configure({ referrer });

--- a/index.html
+++ b/index.html
@@ -16,9 +16,11 @@
       (function(){
         try {
           if (window.polliLib) {
-            // Use a stable referrer for API tiering; avoid hardcoding endpoints elsewhere
-            window.polliLib.configure({ referrer: 'unityailab.com' });
-            window.polliClient = new window.polliLib.PolliClientWeb({ referrer: 'unityailab.com' });
+            // Derive referrer from attribute or window location
+            const cur = document.currentScript;
+            const referrer = (cur && cur.getAttribute('data-referrer')) || window.location.origin;
+            window.polliLib.configure({ referrer });
+            window.polliClient = window.polliLib.getDefaultClient();
 
             // Provide basic helpers used by image features
             if (!window.randomSeed) {

--- a/index.html
+++ b/index.html
@@ -16,9 +16,14 @@
       (function(){
         try {
           if (window.polliLib) {
-            // Derive referrer from attribute or window location
+            // Derive base referrer from attribute or window location (no path segments)
             const cur = document.currentScript;
-            const referrer = (cur && cur.getAttribute('data-referrer')) || window.location.origin;
+            const attrRef = cur && cur.getAttribute('data-referrer');
+            let base = window.location.origin;
+            if (attrRef) {
+              try { base = new URL(attrRef).origin; } catch {}
+            }
+            const referrer = base.endsWith('/') ? base : base + '/';
             window.polliLib.configure({ referrer });
             window.polliClient = window.polliLib.getDefaultClient();
 


### PR DESCRIPTION
## Summary
- Configure PolliLib with a referrer derived from `window.location.origin` or an optional `data-referrer` attribute
- Share the default PolliLib client across modules via `window.polliClient`

## Testing
- `node tests/pollilib-smoke.mjs` *(fetch failed for most requests)*

------
https://chatgpt.com/codex/tasks/task_b_68c5490c8fc0832f895f054b20e2b27d