### PR TITLE
Ensure refreshImage includes referrer parameter

### DIFF
--- a/chat-storage.js
+++ b/chat-storage.js
@@ -375,6 +375,11 @@ document.addEventListener("DOMContentLoaded", () => {
             urlObj.searchParams.set('seed', String(newSeed));
             newUrl = urlObj.toString();
         }
+        const newUrlObj = new URL(newUrl);
+        if (!newUrlObj.searchParams.has('referrer') && window.polliClient?.referrer) {
+            newUrlObj.searchParams.set('referrer', window.polliClient.referrer); // retain referrer for API tiering
+        }
+        const finalUrl = newUrlObj.toString();
         const loadingDiv = document.createElement("div");
         loadingDiv.className = "ai-image-loading";
         const spinner = document.createElement("div");
@@ -396,7 +401,7 @@ document.addEventListener("DOMContentLoaded", () => {
             loadingDiv.style.alignItems = "center";
             showToast("Failed to refresh image");
         };
-        img.src = newUrl;
+        img.src = finalUrl;
     }
     function openImageInNewTab(img, imageId) {
         console.log(`Opening image in new tab with ID: ${imageId}`);

--- a/simple.js
+++ b/simple.js
@@ -603,6 +603,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 urlObj.searchParams.set('seed', String(newSeed));
                 newUrl = urlObj.toString();
             }
+            const newUrlObj = new URL(newUrl);
+            if (!newUrlObj.searchParams.has('referrer') && window.polliClient?.referrer) {
+                newUrlObj.searchParams.set('referrer', window.polliClient.referrer); // retain referrer for API tiering
+            }
+            const finalUrl = newUrlObj.toString();
 
             const loadingDiv = document.createElement("div");
             loadingDiv.className = "simple-ai-image-loading";
@@ -626,7 +631,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 loadingDiv.style.alignItems = "center";
                 window.showToast("Failed to refresh image");
             };
-            img.src = newUrl;
+            img.src = finalUrl;
         }
 
         function openImageInNewTab(img, imageId) {


### PR DESCRIPTION
## Summary
- Retain `referrer` query parameter when regenerating image URLs in `chat-storage.js` and `simple.js`
- Reassign image sources with updated URLs so subsequent refreshes include referrer metadata

## Testing
- `node tests/pollilib-smoke.mjs` *(fails: SyntaxError: Invalid or unexpected token)*

------
https://chatgpt.com/codex/tasks/task_b_68c54d61c9a4832fb9afe37b19160233