### PR TITLE
docs: reference PolliLib client in script comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -461,10 +461,10 @@
     <script defer src="storage.js"></script>
     <script defer src="memory-api.js"></script>
 
-    <!-- chat-core FIRST so pollinationsFetch exists -->
+    <!-- chat-core FIRST so PolliLib's default client helpers are available -->
     <script defer src="chat-core.js"></script>
 
-    <!-- UI now safely uses pollinationsFetch -->
+    <!-- UI now safely uses PolliLib's default client -->
     <script defer src="ui.js"></script>
 
     <script defer src="chat-storage.js"></script>

--- a/tests/pollilib-smoke.mjs
+++ b/tests/pollilib-smoke.mjs
@@ -169,9 +169,7 @@ await step('index.html contains critical tags', async () => {
 const { ok, fail, text } = summary();
 console.log('\n' + text + '\n');
 if (process.env.GITHUB_STEP_SUMMARY) {
-  const md = ['# PolliLib Smoke Tests', '', '```
-' + text + '
-```'].join('\n');
+  const md = ['# PolliLib Smoke Tests', '', '```', text, '```'].join('\n');
   await fs.appendFile(process.env.GITHUB_STEP_SUMMARY, md + '\n');
 }
 // Exit non-zero if any failures to make failures visible in CI (deployment workflow is independent)


### PR DESCRIPTION
## Summary
- clarify script order by referencing PolliLib's default client instead of pollinationsFetch
- fix PolliLib smoke test summary string construction

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node tests/pollilib-smoke.mjs` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c54e0f9008832faa6f51987f1f0a0f