### PR TITLE
Simplify smoke test referrer usage

### DIFF
--- a/tests/pollilib-smoke.mjs
+++ b/tests/pollilib-smoke.mjs
@@ -54,7 +54,7 @@ await step('textModels returns JSON', async () => {
 });
 
 await step('text(prompt) returns string', async () => {
-  const out = await textGet('Say ok', { model: 'openai-mini', referrer: REFERRER }, client);
+  const out = await textGet('Say ok', { model: 'openai-mini' }, client);
   if (typeof out !== 'string' || !out.length) throw new Error('empty text output');
   return `len=${out.length}`;
 });


### PR DESCRIPTION
## Summary
- Remove redundant `referrer` parameter in `pollilib-smoke` test since client already supplies it

## Testing
- `node tests/pollilib-smoke.mjs` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c559348ad8832fbe975db53d2f0661