### PR TITLE
Remove unused User-Agent constant

### DIFF
--- a/polliLib/src/client.js
+++ b/polliLib/src/client.js
@@ -1,5 +1,5 @@
-const DEFAULT_USER_AGENT = `polliLib-web/0.1.0 (+https://pollinations.ai)`;
-
+// Browsers do not allow setting a custom `User-Agent` header, so
+// PolliClientWeb relies on the default browser user agent.
 export class PolliClientWeb {
   constructor({
     referrer = inferReferrer(),


### PR DESCRIPTION
## Summary
- remove unused User-Agent constant from PolliClientWeb
- document that browsers block setting custom User-Agent headers

## Testing
- `node tests/pollilib-smoke.mjs` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c55a2cac9c832f991a77e9214a78ca