### PR TITLE
Separate test and deploy GitHub workflows

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
   # Manual trigger
   workflow_dispatch:
   # Optional: run when using GitHub merge queue
@@ -87,8 +84,7 @@ jobs:
   deploy:
     name: Deploy to Pages
     needs: build
-    # Do not deploy for pull_request events; only push/main, merge_group, dispatch
-    if: github.event_name != 'pull_request'
+    # Runs only on push to main, merge_group, or manual dispatch
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/pollilib-tests.yml
+++ b/.github/workflows/pollilib-tests.yml
@@ -1,9 +1,6 @@
 name: PolliLib Smoke Tests
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -29,5 +26,5 @@ jobs:
       - name: Run smoke tests
         env:
           POLLI_REFERRER: unityailab.com
-        run: node tests/pollilib-smoke.mjs
+        run: npm test
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "unity-chat",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "test": "node tests/pollilib-smoke.mjs"
+  }
 }
 


### PR DESCRIPTION
## Summary
- run PolliLib smoke tests only on pull requests
- deploy Pages only when changes land on main
- add npm test script for easier local runs

## Testing
- `POLLI_REFERRER=unityailab.com npm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c55b674a68832fa7518061a94a8bfd