### PR TITLE
Use markdown AI instruction file

### DIFF
--- a/chat-core.js
+++ b/chat-core.js
@@ -15,9 +15,9 @@ async function apiFetch(url, options = {}, { timeoutMs = 45000 } = {}) {
 }
 window.apiFetch = apiFetch;
 
-// Load global AI instructions from external text file
+// Load global AI instructions from external markdown file
 window.aiInstructions = "";
-window.aiInstructionPromise = fetch("ai-instruct.txt")
+window.aiInstructionPromise = fetch("ai-instruct.md")
     .then(res => res.text())
     .then(text => { window.aiInstructions = text; })
     .catch(err => {
@@ -465,7 +465,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         if (!window.aiInstructions) {
             try {
-                const res = await fetch("ai-instruct.txt", { cache: "no-store" });
+                const res = await fetch("ai-instruct.md", { cache: "no-store" });
                 window.aiInstructions = await res.text();
             } catch (e) {
                 window.aiInstructions = "";


### PR DESCRIPTION
## Summary
- load AI instructions from `ai-instruct.md` instead of `.txt` to match existing file

## Testing
- `npm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c59ff7d3bc832f96276c11c27dc359