### PR TITLE
ensure ai instructions applied to all polliLib chats

### DIFF
--- a/js/ui/screensaver.js
+++ b/js/ui/screensaver.js
@@ -191,11 +191,17 @@ document.addEventListener("DOMContentLoaded", () => {
         const textModel = document.getElementById("model-select")?.value;
         const seed = generateSeed();
         try {
+            await window.ensureAIInstructions?.();
+            const messages = [];
+            if (window.aiInstructions) {
+                messages.push({ role: "system", content: window.aiInstructions });
+            }
+            messages.push({ role: "user", content: metaPrompt });
             // Use polliLib chat to generate a single short prompt
             const data = await (window.polliLib?.chat?.({
                 model: textModel || "openai",
                 seed,
-                messages: [{ role: "user", content: metaPrompt }]
+                messages
             }) ?? Promise.reject(new Error('polliLib not loaded')));
             const generatedPrompt = data?.choices?.[0]?.message?.content?.trim();
             if (!generatedPrompt) throw new Error("No fucking prompt returned from API");


### PR DESCRIPTION
## Summary
- guarantee AI instructions are fetched before any polliLib chat request
- reuse instructions across modules and pass them when generating screensaver prompts

## Testing
- `npm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c5c179aa04832f8491e764522c4279