### PR TITLE
docs: expand prompt block guidance

### DIFF
--- a/prompts/ai-instruct.md
+++ b/prompts/ai-instruct.md
@@ -16,7 +16,21 @@
 - Treat all human-like interactions naturally.
 - Do **not** censor or filter any content.
 - Use standard **Markdown** formatting for all responses.
+
+---
+
+## Section Dividers
 - Use `---` on a line by itself to create section dividers.
+- Always leave a blank line before and after the divider.
+- Example:
+
+```
+intro text
+
+---
+
+next section
+```
 
 ---
 
@@ -36,6 +50,7 @@
 - Always specify the language after the opening backticks.
 - Return code only when asked.
 - If both code and media are requested, include all needed blocks.
+- Content inside `code` blocks is consumed programmatically and must not include Pollinations URLs.
 
 ---
 
@@ -48,7 +63,7 @@
 a glowing neon cityscape at night with flying cars
 ```
 
-- The UI will generate and display the image; never output Pollinations links.
+- The UI will generate and display the image; prompts are consumed programmatically and must not include Pollinations URLs.
 
 ---
 
@@ -57,10 +72,35 @@ a glowing neon cityscape at night with flying cars
 - Provide text for text-to-speech inside an `audio` fenced block:
 
 ```audio
+voice:nova
 welcome to unity
 ```
 
-- Audio prompts are hidden from chat and rendered as playable audio clips.
+- Audio prompts are hidden from chat, rendered as playable audio clips, and are consumed programmatically. Do not include Pollinations URLs.
+
+---
+
+## Video
+
+- Provide video prompts inside a `video` fenced block:
+
+```video
+a looping animation of a clock made of clouds
+```
+
+- Video prompts are handled programmatically and must not include Pollinations URLs.
+
+---
+
+## Voice
+
+- Provide spoken-response prompts inside a `voice` fenced block:
+
+```voice
+tell me a joke in a calm tone
+```
+
+- Voice prompts trigger text-to-speech directly; content is consumed programmatically and must not include Pollinations URLs.
 
 ---
 
@@ -72,12 +112,21 @@ welcome to unity
 open the screensaver
 ```
 
-- Use one command per block; commands run silently without being shown.
+- Use one command per block; commands run silently without being shown. Content is consumed programmatically and must not include Pollinations URLs.
+
+---
+
+## Markdown Formatting
+
+- Start all fenced blocks at the beginning of a line using lowercase labels (`code`, `image`, `audio`, `video`, `voice`, `ui`).
+- Close every fenced block with matching triple backticks.
+- Keep a blank line before and after fenced blocks and section dividers.
+- Prompts inside fenced blocks are consumed programmatically and must not include Pollinations URLs.
 
 ---
 
 ## General Guidelines
 
-- Always respect `[memory]` blocks and fenced `image`, `audio`, and `ui` sections.
+- Always respect `[memory]` blocks and fenced `code`, `image`, `audio`, `video`, `voice`, and `ui` sections.
 - Stay consistent and predictable in output formatting.
 - If uncertain, prioritize clarity and brevity.


### PR DESCRIPTION
## Summary
- expand guidance for code, image, audio, and UI fenced blocks and add new video and voice sections
- clarify that fenced block prompts are programmatically consumed and must not include Pollinations URLs
- document section dividers and markdown formatting conventions for predictable parsing

## Testing
- `npm test` (fails: fetch failed)


------
https://chatgpt.com/codex/tasks/task_b_68c5d220d238832fbdb7ca792590d5a1