### PR TITLE
Sanitize markdown before parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.html
+++ b/index.html
@@ -485,6 +485,7 @@
     <script defer src="js/ui/ui.js"></script>
 
     <script defer src="js/chat/polli-utils.js"></script>
+    <script type="module" defer src="js/chat/markdown-sanitizer.js"></script>
     <script defer src="js/chat/chat-storage.js"></script>
     <script defer src="js/chat/chat-init.js"></script>
     <script defer src="js/ui/simple.js"></script>

--- a/js/chat/chat-init.js
+++ b/js/chat/chat-init.js
@@ -33,7 +33,10 @@ document.addEventListener("DOMContentLoaded", () => {
         const bubbleContent = document.createElement("div");
         bubbleContent.classList.add("message-text");
         if (role === "ai") {
-            bubbleContent.innerHTML = marked.parse(content);
+            const sanitized = window.sanitizeMarkdown
+                ? window.sanitizeMarkdown(content, window.blockedFenceTypes)
+                : content;
+            bubbleContent.innerHTML = marked.parse(sanitized);
             if (imageUrls.length > 0) {
                 imageUrls.forEach(url => {
                     const imageContainer = createImageElement(url, index);

--- a/js/chat/chat-storage.js
+++ b/js/chat/chat-storage.js
@@ -55,7 +55,10 @@ document.addEventListener("DOMContentLoaded", () => {
         const bubbleContent = document.createElement("div");
         bubbleContent.classList.add("message-text");
         if (role === "ai") {
-            bubbleContent.innerHTML = marked.parse(content);
+            const sanitized = window.sanitizeMarkdown
+                ? window.sanitizeMarkdown(content, window.blockedFenceTypes)
+                : content;
+            bubbleContent.innerHTML = marked.parse(sanitized);
             if (imageUrls.length > 0) {
                 imageUrls.forEach(url => {
                     const imageContainer = createImageElement(url);

--- a/js/chat/markdown-sanitizer.js
+++ b/js/chat/markdown-sanitizer.js
@@ -1,0 +1,16 @@
+export const defaultBlockedFenceTypes = ['image', 'audio', 'ui'];
+
+export function sanitizeMarkdown(content, blocked = defaultBlockedFenceTypes) {
+  if (!content) return '';
+  const pattern = /```(\w+)\n[\s\S]*?```/g;
+  return content.replace(pattern, (match, type) => {
+    return blocked.includes(type.toLowerCase()) ? '' : match;
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.sanitizeMarkdown = sanitizeMarkdown;
+  if (!window.blockedFenceTypes) {
+    window.blockedFenceTypes = [...defaultBlockedFenceTypes];
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "unity-chat",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "unity-chat",
+      "devDependencies": {
+        "marked": "^11.2.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-11.2.0.tgz",
+      "integrity": "sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node tests/pollilib-smoke.mjs"
+    "test": "node tests/pollilib-smoke.mjs && node tests/markdown-sanitization.mjs"
+  },
+  "devDependencies": {
+    "marked": "^11.2.0"
   }
 }
 

--- a/tests/markdown-sanitization.mjs
+++ b/tests/markdown-sanitization.mjs
@@ -1,0 +1,27 @@
+import { strict as assert } from 'node:assert';
+import { marked } from 'marked';
+import { sanitizeMarkdown } from '../js/chat/markdown-sanitizer.js';
+
+const input = [
+  'Hello',
+  '',
+  '```image',
+  'https://example.com/cat.png',
+  '```',
+  '',
+  '```javascript',
+  "console.log('hi');",
+  '```',
+  '',
+  '---',
+  ''
+].join('\n');
+
+const sanitized = sanitizeMarkdown(input);
+assert(!sanitized.includes('cat.png'), 'Blocked fence content should be removed');
+
+const html = marked.parse(sanitized);
+assert(html.includes('<code'), 'Code block should remain after sanitization');
+assert(html.includes('<hr'), 'Horizontal rule should be rendered');
+
+console.log('markdown-sanitization test passed');


### PR DESCRIPTION
## Summary
- strip residual fenced blocks like `image`, `audio`, or `ui` before passing messages to marked
- add reusable markdown sanitizer and unit test to verify code blocks and `<hr>` still render
- wire sanitizer into chat message rendering and load via new module

## Testing
- `npm test` *(fails: textModels returns JSON — fetch failed, text(prompt) returns string — fetch failed, chat basic response — fetch failed, search convenience returns text — fetch failed, imageModels returns JSON — fetch failed, image fetch small blob — fetch failed, mcp generateImageBase64 returns base64 — fetch failed, vision with data URL — fetch failed, audio.tts returns audio blob — fetch failed, mcp list helpers return arrays/objects — fetch failed, pipeline end-to-end — fetch failed)*
- `node tests/markdown-sanitization.mjs`


------
https://chatgpt.com/codex/tasks/task_b_68c5f4bcbf90832facf08d8e9f9a741d