### PR TITLE
Add extensive test scripts and enhance testing workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,392 @@
     "": {
       "name": "unity-chat",
       "devDependencies": {
+        "jsdom": "^27.0.0",
         "marked": "^11.2.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.0.4.tgz",
+      "integrity": "sha512-cKjSKvWGmAziQWbCouOsFwb14mp1betm8Y7Fn+yglDMUUu3r9DCbJ9iJbeFDenLMqFbIMC0pQP8K+B8LAxX3OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.1.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.5.4.tgz",
+      "integrity": "sha512-RNSNk1dnB8lAn+xdjlRoM4CzdVrHlmXZtSXAWs2jyl4PiBRWqTZr9ML5M710qgd9RPTBsVG6P0SLy7dwy0Foig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.14.tgz",
+      "integrity": "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.0.tgz",
+      "integrity": "sha512-RveJPnk3m7aarYQ2bJ6iw+Urh55S6FzUiqtBq+TihnTDP4cI8y/TYDqGOyqgnG1J1a6BxJXZsV9JFSTulm9Z7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.0.3",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.14",
+        "css-tree": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+      "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
+      "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.5.4",
+        "cssstyle": "^5.3.0",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.3.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0",
+        "ws": "^8.18.2",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
+      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/marked": {
@@ -20,6 +405,300 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.14.tgz",
+      "integrity": "sha512-lMNHE4aSI3LlkMUMicTmAG3tkkitjOQGDTFboPJwAg2kJXKP1ryWEyqujktg5qhrFZOkk5YFzgkxg3jErE+i5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.14"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.14.tgz",
+      "integrity": "sha512-viZGNK6+NdluOJWwTO9olaugx0bkKhscIdriQQ+lNNhwitIKvb+SvhbYgnCz6j9p7dX3cJntt4agQAKMXLjJ5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.0.0.tgz",
+      "integrity": "sha512-+0q+Pc6oUhtbbeUfuZd4heMNOLDJDdagYxv756mCf9vnLF+NTj4zvv5UyYNkHJpc3CJIesMVoEIOdhi7L9RObA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.1",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node tests/pollilib-smoke.mjs && node tests/markdown-sanitization.mjs && node tests/ai-response.mjs && node tests/json-tools.mjs"
+    "test": "node tests/pollilib-smoke.mjs && node tests/markdown-sanitization.mjs && node tests/ai-response.mjs && node tests/json-tools.mjs && node testscripts/run-all.mjs"
   },
   "devDependencies": {
+    "jsdom": "^27.0.0",
     "marked": "^11.2.0"
   }
 }
-

--- a/testscripts/_helpers.mjs
+++ b/testscripts/_helpers.mjs
@@ -1,0 +1,34 @@
+import { ReadableStream } from 'node:stream/web';
+
+export class MockResponse {
+  constructor({ ok = true, status = 200, blob = '', text = '', json = null, streamMessages = null } = {}) {
+    this.ok = ok;
+    this.status = status;
+    this._blob = blob;
+    this._text = text;
+    this._json = json;
+    if (streamMessages) {
+      const encoder = new TextEncoder();
+      this.body = new ReadableStream({
+        start(controller) {
+          for (const msg of streamMessages) {
+            controller.enqueue(encoder.encode(`data: ${msg}\n\n`));
+          }
+          controller.close();
+        }
+      });
+    }
+  }
+  async blob() { return this._blob; }
+  async text() { return this._text; }
+  async json() { return this._json; }
+}
+
+export class MockClient {
+  constructor() {
+    this.imageBase = 'https://image.test';
+    this.textBase = 'https://text.test';
+  }
+  async get(url, opts) { return new MockResponse({}); }
+  async postJson(url, body) { return new MockResponse({}); }
+}

--- a/testscripts/audio-stt.mjs
+++ b/testscripts/audio-stt.mjs
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+import { stt } from '../js/polliLib/src/audio.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const client = new MockClient();
+client.postJson = async () => new MockResponse({ json: { text: 'ok' } });
+const data = new Uint8Array([1,2,3]);
+const res = await stt({ data, format: 'wav', question: '?' }, client);
+assert.deepEqual(res, { text: 'ok' });

--- a/testscripts/audio-tts.mjs
+++ b/testscripts/audio-tts.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import { tts } from '../js/polliLib/src/audio.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const client = new MockClient();
+client.get = async () => new MockResponse({ blob: 'audio' });
+const result = await tts('hello', {}, client);
+assert.equal(result, 'audio');

--- a/testscripts/client-class.mjs
+++ b/testscripts/client-class.mjs
@@ -1,0 +1,5 @@
+import assert from 'node:assert/strict';
+import { PolliClientWeb } from '../js/polliLib/src/client.js';
+
+const client = new PolliClientWeb();
+assert.equal(client.imageBase, 'https://image.pollinations.ai');

--- a/testscripts/client-getdefault.mjs
+++ b/testscripts/client-getdefault.mjs
@@ -1,0 +1,6 @@
+import assert from 'node:assert/strict';
+import { getDefaultClient, PolliClientWeb, setDefaultClient } from '../js/polliLib/src/client.js';
+
+setDefaultClient(null);
+const client = getDefaultClient();
+assert.ok(client instanceof PolliClientWeb);

--- a/testscripts/client-setdefault.mjs
+++ b/testscripts/client-setdefault.mjs
@@ -1,0 +1,6 @@
+import assert from 'node:assert/strict';
+import { getDefaultClient, setDefaultClient } from '../js/polliLib/src/client.js';
+
+const custom = { custom: true };
+setDefaultClient(custom);
+assert.equal(getDefaultClient(), custom);

--- a/testscripts/feeds-imageFeed.mjs
+++ b/testscripts/feeds-imageFeed.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { imageFeed } from '../js/polliLib/src/feeds.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const client = new MockClient();
+client.get = async () => new MockResponse({ streamMessages: ['{"a":1}', '{"b":2}'] });
+const gen = imageFeed({}, client);
+const arr = [];
+for await (const item of gen) arr.push(item);
+assert.deepEqual(arr, [{a:1}, {b:2}]);

--- a/testscripts/feeds-textFeed.mjs
+++ b/testscripts/feeds-textFeed.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { textFeed } from '../js/polliLib/src/feeds.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const client = new MockClient();
+client.get = async () => new MockResponse({ streamMessages: ['{"x":1}'] });
+const gen = textFeed({ limit:1 }, client);
+const arr = [];
+for await (const item of gen) arr.push(item);
+assert.deepEqual(arr, [{x:1}]);

--- a/testscripts/image-image.mjs
+++ b/testscripts/image-image.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import { image } from '../js/polliLib/src/image.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const client = new MockClient();
+client.get = async () => new MockResponse({ blob: 'img' });
+const res = await image('cat', {}, client);
+assert.equal(res, 'img');

--- a/testscripts/image-models.mjs
+++ b/testscripts/image-models.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import { imageModels } from '../js/polliLib/src/image.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const client = new MockClient();
+client.get = async () => new MockResponse({ json: ['a','b'] });
+const models = await imageModels(client);
+assert.deepEqual(models, ['a','b']);

--- a/testscripts/markdown-sanitizer.mjs
+++ b/testscripts/markdown-sanitizer.mjs
@@ -1,0 +1,7 @@
+import assert from 'node:assert/strict';
+import { sanitizeMarkdown } from '../js/chat/markdown-sanitizer.js';
+
+const md = 'Hello\n```image\na\n```\n```code\nx\n```';
+const res = sanitizeMarkdown(md);
+assert.ok(!res.includes('image'));
+assert.ok(res.includes('```code')); 

--- a/testscripts/mcp-generateImageBase64.mjs
+++ b/testscripts/mcp-generateImageBase64.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import { generateImageBase64 } from '../js/polliLib/src/mcp.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const client = new MockClient();
+client.get = async () => new MockResponse({ blob: new Blob(['hi']) });
+const b64 = await generateImageBase64(client, { prompt: 'hi' });
+assert.ok(typeof b64 === 'string');

--- a/testscripts/mcp-generateImageUrl.mjs
+++ b/testscripts/mcp-generateImageUrl.mjs
@@ -1,0 +1,7 @@
+import assert from 'node:assert/strict';
+import { generateImageUrl } from '../js/polliLib/src/mcp.js';
+
+const client = { imageBase: 'https://image.test', referrer: 'r' };
+const url = generateImageUrl(client, { prompt: 'cat', width: 1 });
+assert.ok(url.includes('prompt/cat'));
+assert.ok(url.includes('width=1'));

--- a/testscripts/mcp-listAudioVoices.mjs
+++ b/testscripts/mcp-listAudioVoices.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import { listAudioVoices } from '../js/polliLib/src/mcp.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const client = new MockClient();
+client.get = async () => new MockResponse({ json: { 'openai-audio': { voices: ['v1'] } } });
+const voices = await listAudioVoices(client);
+assert.deepEqual(voices, ['v1']);

--- a/testscripts/mcp-listImageModels.mjs
+++ b/testscripts/mcp-listImageModels.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import { listImageModels } from '../js/polliLib/src/mcp.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const client = new MockClient();
+client.get = async () => new MockResponse({ json: ['x'] });
+const models = await listImageModels(client);
+assert.deepEqual(models, ['x']);

--- a/testscripts/mcp-listTextModels.mjs
+++ b/testscripts/mcp-listTextModels.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import { listTextModels } from '../js/polliLib/src/mcp.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const client = new MockClient();
+client.get = async () => new MockResponse({ json: {a:1} });
+const models = await listTextModels(client);
+assert.deepEqual(models, {a:1});

--- a/testscripts/mcp-serverName.mjs
+++ b/testscripts/mcp-serverName.mjs
@@ -1,0 +1,4 @@
+import assert from 'node:assert/strict';
+import { serverName } from '../js/polliLib/src/mcp.js';
+
+assert.equal(serverName(), 'pollinations-multimodal-api');

--- a/testscripts/mcp-toolDefinitions.mjs
+++ b/testscripts/mcp-toolDefinitions.mjs
@@ -1,0 +1,5 @@
+import assert from 'node:assert/strict';
+import { toolDefinitions } from '../js/polliLib/src/mcp.js';
+
+const defs = toolDefinitions();
+assert.ok(Array.isArray(defs.tools));

--- a/testscripts/pipeline-context.mjs
+++ b/testscripts/pipeline-context.mjs
@@ -1,0 +1,6 @@
+import assert from 'node:assert/strict';
+import { Context } from '../js/polliLib/src/pipeline.js';
+
+const ctx = new Context();
+ctx.set('a',1);
+assert.equal(ctx.get('a'),1);

--- a/testscripts/pipeline-imagestep.mjs
+++ b/testscripts/pipeline-imagestep.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { ImageStep } from '../js/polliLib/src/pipeline.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const step = new ImageStep({ prompt:'hi', outKey:'img' });
+const client = new MockClient();
+client.get = async () => new MockResponse({ blob: 'imgblob' });
+const context = new Map();
+await step.run({ client, context });
+assert.equal(context.get('img').blob, 'imgblob');

--- a/testscripts/pipeline-pipeline.mjs
+++ b/testscripts/pipeline-pipeline.mjs
@@ -1,0 +1,7 @@
+import assert from 'node:assert/strict';
+import { Pipeline } from '../js/polliLib/src/pipeline.js';
+
+const p = new Pipeline();
+p.step({ run: async () => {} });
+const ctx = await p.execute();
+assert.ok(ctx instanceof Map);

--- a/testscripts/pipeline-textgetstep.mjs
+++ b/testscripts/pipeline-textgetstep.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { TextGetStep } from '../js/polliLib/src/pipeline.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const step = new TextGetStep({ prompt:'hi', outKey:'resp' });
+const client = new MockClient();
+client.get = async () => new MockResponse({ text: 'ok' });
+const context = new Map();
+await step.run({ client, context });
+assert.equal(context.get('resp'), 'ok');

--- a/testscripts/pipeline-ttsstep.mjs
+++ b/testscripts/pipeline-ttsstep.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { TtsStep } from '../js/polliLib/src/pipeline.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const step = new TtsStep({ text:'hi', outKey:'aud' });
+const client = new MockClient();
+client.get = async () => new MockResponse({ blob: 'audblob' });
+const context = new Map();
+await step.run({ client, context });
+assert.equal(context.get('aud').blob, 'audblob');

--- a/testscripts/pipeline-visionurlstep.mjs
+++ b/testscripts/pipeline-visionurlstep.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { VisionUrlStep } from '../js/polliLib/src/pipeline.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const step = new VisionUrlStep({ imageUrl:'http://x', outKey:'vis' });
+const client = new MockClient();
+client.postJson = async () => new MockResponse({ json:{ answer:'ok' } });
+const context = new Map();
+await step.run({ client, context });
+assert.deepEqual(context.get('vis'), { answer:'ok' });

--- a/testscripts/polli-utils.mjs
+++ b/testscripts/polli-utils.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!doctype html><p></p>', { url: 'https://example.com' });
+global.window = dom.window;
+global.document = dom.window.document;
+global.polliClient = { imageBase: 'https://image.pollinations.ai', referrer: 'ref' };
+global.polliLib = { mcp: { generateImageUrl: (client, { prompt }) => `${client.imageBase}/prompt/${encodeURIComponent(prompt)}` } };
+
+await import('../js/chat/polli-utils.js');
+const { url, error } = window.refreshPolliImage('https://image.pollinations.ai/prompt/test', {});
+assert.ok(url);

--- a/testscripts/run-all.mjs
+++ b/testscripts/run-all.mjs
@@ -1,0 +1,12 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const dir = path.dirname(new URL(import.meta.url).pathname);
+const files = await fs.readdir(dir);
+for (const file of files) {
+  if (file.endsWith('.mjs') && !['run-all.mjs','_helpers.mjs'].includes(file)) {
+    console.log('Running', file);
+    await import(`./${file}`);
+  }
+}
+console.log('All test scripts executed');

--- a/testscripts/sse-events.mjs
+++ b/testscripts/sse-events.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import { sseEvents } from '../js/polliLib/src/sse.js';
+import { MockResponse } from './_helpers.mjs';
+
+const resp = new MockResponse({ streamMessages:['{"a":1}','{"b":2}'] });
+const out = [];
+for await (const m of sseEvents(resp)) out.push(m);
+assert.deepEqual(out, ['{"a":1}','{"b":2}']);

--- a/testscripts/text-chat.mjs
+++ b/testscripts/text-chat.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import { chat } from '../js/polliLib/src/text.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const client = new MockClient();
+client.postJson = async () => new MockResponse({ json:{ choices:[{message:{content:'ok'}}] } });
+const res = await chat({ model:'m', messages:[] }, client);
+assert.deepEqual(res, { choices:[{message:{content:'ok'}}] });

--- a/testscripts/text-search.mjs
+++ b/testscripts/text-search.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import { search } from '../js/polliLib/src/text.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const client = new MockClient();
+client.get = async () => new MockResponse({ text: 'res' });
+const res = await search('q', 'model', client);
+assert.equal(res, 'res');

--- a/testscripts/text-text.mjs
+++ b/testscripts/text-text.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import { text } from '../js/polliLib/src/text.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const client = new MockClient();
+client.get = async () => new MockResponse({ text: 'hello' });
+const res = await text('hi', {}, client);
+assert.equal(res, 'hello');

--- a/testscripts/text-textModels.mjs
+++ b/testscripts/text-textModels.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import { textModels } from '../js/polliLib/src/text.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const client = new MockClient();
+client.get = async () => new MockResponse({ json: ['a'] });
+const models = await textModels(client);
+assert.deepEqual(models, ['a']);

--- a/testscripts/tools-chatWithTools.mjs
+++ b/testscripts/tools-chatWithTools.mjs
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+import { chatWithTools } from '../js/polliLib/src/tools.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const client = new MockClient();
+client.postJson = async () => new MockResponse({ json:{ choices:[{message:{content:'ok'}}] } });
+const toolbox = { get() {} };
+const resp = await chatWithTools({ client, model:'m', messages:[], tools:[], toolbox });
+assert.deepEqual(resp, { choices:[{message:{content:'ok'}}] });

--- a/testscripts/tools-functionTool.mjs
+++ b/testscripts/tools-functionTool.mjs
@@ -1,0 +1,5 @@
+import assert from 'node:assert/strict';
+import { functionTool } from '../js/polliLib/src/tools.js';
+
+const t = functionTool('n','d',{type:'object'});
+assert.equal(t.type, 'function');

--- a/testscripts/tools-toolbox.mjs
+++ b/testscripts/tools-toolbox.mjs
@@ -1,0 +1,6 @@
+import assert from 'node:assert/strict';
+import { ToolBox } from '../js/polliLib/src/tools.js';
+
+const box = new ToolBox();
+box.register('a', ()=>'b');
+assert.equal(box.get('a')(), 'b');

--- a/testscripts/vision-vision.mjs
+++ b/testscripts/vision-vision.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import { vision } from '../js/polliLib/src/vision.js';
+import { MockClient, MockResponse } from './_helpers.mjs';
+
+const client = new MockClient();
+client.postJson = async () => new MockResponse({ json:{ answer:'yes' } });
+const res = await vision({ imageUrl:'http://x' }, client);
+assert.deepEqual(res, { answer:'yes' });


### PR DESCRIPTION
## Summary
- expand `test` script to run all test modules and new scripts
- add `jsdom` dev dependency and dozens of test files in `testscripts`
- include test runner that imports every script in `testscripts`

## Testing
- `npm test` *(fails: fetch failed in existing PolliLib smoke tests)*

------
https://chatgpt.com/codex/tasks/task_b_68c67023ad648329a00dca4cda38c7ec