### PR TITLE
fix screensaver prompt generation

### DIFF
--- a/js/ui/screensaver.js
+++ b/js/ui/screensaver.js
@@ -191,13 +191,8 @@ document.addEventListener("DOMContentLoaded", () => {
         const textModel = document.getElementById("model-select")?.value;
         const seed = generateSeed();
         try {
-            await window.ensureAIInstructions?.();
-            const messages = [];
-            if (window.aiInstructions) {
-                messages.push({ role: "system", content: window.aiInstructions });
-            }
-            messages.push({ role: "user", content: metaPrompt });
-            // Use polliLib chat to generate a single short prompt
+            const messages = [{ role: "user", content: metaPrompt }];
+            // Use polliLib chat to generate a single short prompt solely from the meta prompt
             const data = await (window.polliLib?.chat?.({
                 model: textModel || "openai",
                 seed,


### PR DESCRIPTION
## Summary
- ensure screensaver dynamic prompts use only the meta prompt

## Testing
- `npm test` *(fails: fetch failed for multiple PolliLib tests)*

------
https://chatgpt.com/codex/tasks/task_b_68c6819b1454832999835da3f37d84ec