### PR TITLE
Fix polliLib initialization so screensaver loads images

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
     <link rel="stylesheet" href="js/ui/stylesScreensaver.css">
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script defer src="js/polliLib/polliLib-web.global.js"></script>
-    <script defer>
+    <script>
       // Configure polliLib default client and expose an explicit client for MCP helpers
-      (function(){
+      window.addEventListener('DOMContentLoaded', () => {
         try {
           if (window.polliLib) {
             // Derive base referrer from attribute or window location (no path segments)
@@ -59,7 +59,7 @@
             }
           }
         } catch (e) { console.warn('polliLib configure failed', e); }
-      })();
+      });
     </script>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- ensure polliLib default client is configured after DOM loads so screensaver can generate images

## Testing
- `npm test` *(fails: textModels returns JSON — fetch failed, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68c69d1dc86c83299043fd57284b4287