### PR TITLE
Fix screensaver element checks and inline fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8">
     <title>Unity AI Lab Chat</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy"
+      content="default-src 'self';
+               img-src 'self' data: blob: https://image.pollinations.ai https://image.pollinations.ai/* https://via.placeholder.com;
+               connect-src 'self' https://image.pollinations.ai;
+               media-src 'self' blob: data:;
+               frame-src 'self';
+               script-src 'self' 'unsafe-inline';
+               style-src 'self' 'unsafe-inline';">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css">
@@ -64,8 +72,8 @@
   </head>
   <body>
     <div id="screensaver-container" class="screensaver hidden">
-      <img id="screensaver-image1" alt="Screensaver Image" style="opacity: 0;">
-      <img id="screensaver-image2" alt="Screensaver Image" style="opacity: 0;">
+      <img id="screensaver-image1" class="screensaver-image" alt="Screensaver Image">
+      <img id="screensaver-image2" class="screensaver-image" alt="Screensaver Image">
       <div id="screensaver-thumbnails-wrapper" class="screensaver-thumbnails-wrapper">
         <button id="screensaver-thumb-left" class="thumb-nav" aria-label="Scroll thumbnails left">&#9664;</button>
         <div id="screensaver-thumbnails" class="screensaver-thumbnails">

--- a/js/ui/screensaver.js
+++ b/js/ui/screensaver.js
@@ -22,6 +22,17 @@ document.addEventListener("DOMContentLoaded", () => {
     const thumbLeftButton = document.getElementById("screensaver-thumb-left");
     const thumbRightButton = document.getElementById("screensaver-thumb-right");
 
+    const required = [
+        screensaverContainer, toggleScreensaverButton, fullscreenButton, stopButton,
+        playPauseButton, saveButton, copyButton, hideButton,
+        screensaverImage1, screensaverImage2, promptInput, timerInput,
+        aspectSelect, enhanceCheckbox, privateCheckbox, transitionDurationInput, modelSelect
+    ].filter(Boolean);
+
+    if (required.length < 17) {
+        console.error("Missing required DOM elements. Check your IDs.");
+    }
+
     let screensaverActive = false;
     let imageInterval = null;
     let promptInterval = null;
@@ -38,6 +49,13 @@ document.addEventListener("DOMContentLoaded", () => {
     const MAX_HISTORY = 10;
     const EMPTY_THUMBNAIL = "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=";
     const PROMPT_UPDATE_INTERVAL = 20000;
+    const DATA_FALLBACK =
+        "data:image/svg+xml;charset=utf-8," +
+        encodeURIComponent(`<svg xmlns='http://www.w3.org/2000/svg' width='1024' height='576'>
+    <rect width='100%' height='100%' fill='black'/>
+    <text x='50%' y='50%' fill='white' font-size='28' text-anchor='middle' dominant-baseline='middle'>
+      Image failed to load
+    </text></svg>`);
 
     let settings = {
         prompt: '',
@@ -49,21 +67,21 @@ document.addEventListener("DOMContentLoaded", () => {
         transitionDuration: 1
     };
 
-    toggleScreensaverButton.title = "Toggle the screensaver on/off.";
-    fullscreenButton.title = "Go full screen (or exit it).";
-    stopButton.title = "Stop the screensaver.";
-    playPauseButton.title = "Play or pause the image rotation.";
-    saveButton.title = "Save the current screensaver image.";
-    copyButton.title = "Copy the current screensaver image to clipboard.";
-    hideButton.title = "Hide or show controls and thumbnails.";
-    promptInput.title = "Prompt for the AI to create images from.";
-    timerInput.title = "Interval between new images (in seconds).";
-    aspectSelect.title = "Select the aspect ratio for the generated image.";
-    modelSelect.title = "Choose the image-generation model.";
-    enhanceCheckbox.title = "If enabled, the prompt is 'enhanced' via an LLM.";
-    privateCheckbox.title = "If enabled, the image won't appear on the public feed.";
-    transitionDurationInput.title = "Set the duration of image transitions in seconds.";
-    if (restartPromptButton) restartPromptButton.title = "Toggle automatic prompt generation on/off.";
+    toggleScreensaverButton && (toggleScreensaverButton.title = "Toggle the screensaver on/off.");
+    fullscreenButton && (fullscreenButton.title = "Go full screen (or exit it).");
+    stopButton && (stopButton.title = "Stop the screensaver.");
+    playPauseButton && (playPauseButton.title = "Play or pause the image rotation.");
+    saveButton && (saveButton.title = "Save the current screensaver image.");
+    copyButton && (copyButton.title = "Copy the current screensaver image to clipboard.");
+    hideButton && (hideButton.title = "Hide or show controls and thumbnails.");
+    promptInput && (promptInput.title = "Prompt for the AI to create images from.");
+    timerInput && (timerInput.title = "Interval between new images (in seconds).");
+    aspectSelect && (aspectSelect.title = "Select the aspect ratio for the generated image.");
+    modelSelect && (modelSelect.title = "Choose the image-generation model.");
+    enhanceCheckbox && (enhanceCheckbox.title = "If enabled, the prompt is 'enhanced' via an LLM.");
+    privateCheckbox && (privateCheckbox.title = "If enabled, the image won't appear on the public feed.");
+    transitionDurationInput && (transitionDurationInput.title = "Set the duration of image transitions in seconds.");
+    restartPromptButton && (restartPromptButton.title = "Toggle automatic prompt generation on/off.");
 
     function saveScreensaverSettings() {
         try {
@@ -284,9 +302,11 @@ document.addEventListener("DOMContentLoaded", () => {
                         enhance: !!enhance
                     });
                 }
-            } catch (e) { console.warn('polliLib generateImageUrl failed', e); }
-            // Fallback to placeholder if polliLib not available
-            return "https://via.placeholder.com/512?text=Image+Unavailable";
+                console.warn("polliLib not loaded; using fallback URL");
+            } catch (e) {
+                console.warn('generateImageUrl failed', e);
+            }
+            return DATA_FALLBACK;
         })();
         console.log("Generated new image URL via polliLib:", url);
 
@@ -312,20 +332,15 @@ document.addEventListener("DOMContentLoaded", () => {
         nextImgElement.onload = () => handleImageLoad("Image loaded successfully, added to history:");
 
         nextImgElement.onerror = () => {
-            const fallbackUrl = "https://via.placeholder.com/512?text=Image+Failed";
-            nextImgElement.src = fallbackUrl;
-            nextImgElement.onload = () => handleImageLoad("Image failed, added fallback to history:");
-            nextImgElement.onerror = () => {
-                console.error("Fallback image also failed to load.");
-            };
+            nextImgElement.src = DATA_FALLBACK;
+            nextImgElement.onload = () => handleImageLoad("External image blocked; showed inline fallback:");
         };
 
         try {
-            await preloadImage(url);
             nextImgElement.src = url;
+            await preloadImage(url);
         } catch (err) {
-            const fallbackUrl = "https://via.placeholder.com/512?text=Image+Failed";
-            nextImgElement.src = fallbackUrl;
+            nextImgElement.src = DATA_FALLBACK;
         } finally {
             isTransitioning = false;
         }

--- a/js/ui/stylesScreensaver.css
+++ b/js/ui/stylesScreensaver.css
@@ -9,6 +9,12 @@
   background-color: #000000;
 }
 
+#screensaver-container {
+  position: fixed;
+  inset: 0;
+  background: #000;
+}
+
 .screensaver img {
   position: absolute;
   top: 0;
@@ -19,6 +25,16 @@
   z-index: 0;
   transition: opacity var(--transition-duration, 1s) ease;
   display: block;
+}
+
+.screensaver-image {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: opacity var(--transition-duration, 1s) ease;
+  opacity: 0;
 }
 
 


### PR DESCRIPTION
## Summary
- Guard screensaver initialization against missing DOM nodes and add data URL fallback
- Harden image loading with polliLib URL generation, immediate src assignment, and inline fallback
- Enforce CSP and add styles for screensaver container and images

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c6a74b846c832992893d3a9f920269