### PR TITLE
Remove placeholder images and tighten apple tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy"
       content="default-src 'self';
-               img-src 'self' data: blob: https://image.pollinations.ai https://image.pollinations.ai/* https://via.placeholder.com;
+               img-src 'self' data: blob: https://image.pollinations.ai https://image.pollinations.ai/*;
                connect-src 'self' https://image.pollinations.ai;
                media-src 'self' blob: data:;
                frame-src 'self';

--- a/js/chat/chat-init.js
+++ b/js/chat/chat-init.js
@@ -657,12 +657,9 @@ document.addEventListener("DOMContentLoaded", () => {
                         nologo: true
                     });
                     voiceChatImage.src = url;
-                } else {
-                    voiceChatImage.src = "https://via.placeholder.com/512?text=Image+Unavailable";
                 }
             } catch (e) {
                 console.warn('polliLib generateImageUrl failed', e);
-                voiceChatImage.src = "https://via.placeholder.com/512?text=Image+Unavailable";
             }
         };
         updateImage();

--- a/js/chat/chat-storage.js
+++ b/js/chat/chat-storage.js
@@ -655,12 +655,9 @@ document.addEventListener("DOMContentLoaded", () => {
                         nologo: true
                     });
                     voiceChatImage.src = url;
-                } else {
-                    voiceChatImage.src = "https://via.placeholder.com/512?text=Image+Unavailable";
                 }
             } catch (e) {
                 console.warn('polliLib generateImageUrl failed', e);
-                voiceChatImage.src = "https://via.placeholder.com/512?text=Image+Unavailable";
             }
             voiceChatImage.dataset.imageId = imageId;
             voiceChatImage.onload = () => {

--- a/js/ui/screensaver.js
+++ b/js/ui/screensaver.js
@@ -397,7 +397,7 @@ document.addEventListener("DOMContentLoaded", () => {
             updateThumbnailHistory();
         };
         nextImgElement.onerror = () => {
-            nextImgElement.src = "https://via.placeholder.com/512?text=Image+Failed";
+            nextImgElement.src = EMPTY_THUMBNAIL;
             nextImgElement.style.opacity = '1';
             currentImage = nextImage;
             updateThumbnailHistory();

--- a/tests/pollilib-smoke.mjs
+++ b/tests/pollilib-smoke.mjs
@@ -56,27 +56,33 @@ await step('textModels returns JSON', async () => {
   return `keys: ${JSON.stringify(keys)}`;
 });
 
-await step('text(prompt) returns string', async () => {
+await step('text(prompt) mentions apple', async () => {
   const out = await textGet('apple', { model: 'openai-mini' }, client);
-  if (typeof out !== 'string' || !out.length) throw new Error('empty text output');
-  return `len=${out.length}`;
+  if (typeof out !== 'string' || !out.toLowerCase().includes('apple')) {
+    throw new Error('text output missing apple');
+  }
+  return `ok`;
 });
 
-await step('chat basic response', async () => {
+await step('chat basic response mentions apple', async () => {
   const messages = [
     { role: 'system', content: 'You are concise.' },
     { role: 'user', content: 'apple' }
   ];
   const data = await chat({ messages, /* model omitted to use server default */ }, client);
   const content = data?.choices?.[0]?.message?.content;
-  if (!content || typeof content !== 'string') throw new Error('missing choices[0].message.content');
-  return `len=${content.length}`;
+  if (!content || typeof content !== 'string' || !content.toLowerCase().includes('apple')) {
+    throw new Error('chat response missing apple');
+  }
+  return 'ok';
 });
 
-await step('search convenience returns text', async () => {
+await step('search convenience mentions apple', async () => {
   const out = await search('apple', 'searchgpt', client);
-  if (typeof out !== 'string' || !out.length) throw new Error('empty search output');
-  return `len=${out.length}`;
+  if (typeof out !== 'string' || !out.toLowerCase().includes('apple')) {
+    throw new Error('search output missing apple');
+  }
+  return 'ok';
 });
 
 await step('imageModels returns JSON', async () => {
@@ -114,13 +120,16 @@ await step('mcp generateImageBase64 returns base64', async () => {
   return `len=${b64.length}`;
 });
 
-await step('vision with data URL', async () => {
+await step('vision identifies apple image', async () => {
   const blob = await image('apple', { width: 16, height: 16, private: true, nologo: true, safe: true }, client);
   const b64 = await blobToBase64(blob);
   const dataUrl = `data:image/png;base64,${b64}`;
   const resp = await vision({ imageUrl: dataUrl, question: 'What fruit is this?' }, client);
   const msg = resp?.choices?.[0]?.message?.content;
-  return msg ? `len=${msg.length}` : 'no content';
+  if (!msg || !msg.toLowerCase().includes('apple')) {
+    throw new Error('vision response missing apple');
+  }
+  return 'ok';
 });
 
 await step('audio.tts returns audio blob', async () => {


### PR DESCRIPTION
## Summary
- Drop external placeholder.com references and rely on polliLib URLs or empty thumbnails
- Ensure voice chat and screensaver use polliLib without fallback placeholders
- Verify PolliLib outputs mention "apple" in smoke tests

## Testing
- `node tests/markdown-sanitization.mjs`
- `node tests/ai-response.mjs`
- `node tests/json-tools.mjs`
- `timeout 60 node tests/pollilib-smoke.mjs` *(fails: text output missing apple; vision response missing apple)*

------
https://chatgpt.com/codex/tasks/task_b_68c6b02818cc8329a510cdff0bc9a5ae