### PR TITLE
Simplify PolliLib API calls

### DIFF
--- a/js/chat/chat-core.js
+++ b/js/chat/chat-core.js
@@ -260,37 +260,13 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     const polliTools = window.polliLib?.tools;
-    const toolDefinitions = polliTools ? [
-        polliTools.functionTool('image', 'Generate an image', {
-            type: 'object',
-            properties: { prompt: { type: 'string', description: 'Image description' } },
-            required: ['prompt']
-        }),
-        polliTools.functionTool('tts', 'Convert text to speech', {
-            type: 'object',
-            properties: { text: { type: 'string', description: 'Text to speak' } },
-            required: ['text']
-        }),
-        polliTools.functionTool('ui', 'Execute a UI command', {
-            type: 'object',
-            properties: { command: { type: 'string', description: 'Command to run' } },
-            required: ['command']
-        })
-    ] : [];
 
     const toolbox = polliTools ? new polliTools.ToolBox() : { register() { return this; }, get() { return null; } };
     toolbox
         .register('image', async ({ prompt }) => {
             if (!(window.polliLib && window.polliClient)) return {};
             try {
-                const url = window.polliLib.mcp.generateImageUrl(window.polliClient, {
-                    prompt,
-                    width: 512,
-                    height: 512,
-                    private: true,
-                    nologo: true,
-                    safe: true
-                });
+                const url = window.polliLib.mcp.generateImageUrl(window.polliClient, { prompt });
                 return { imageUrl: url };
             } catch (e) {
                 console.warn('polliLib generateImageUrl failed', e);
@@ -603,7 +579,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         try {
             // Use polliLib OpenAI-compatible chat endpoint
-            const data = await (window.polliLib?.chat?.({ model, messages, tools: toolDefinitions }) ?? Promise.reject(new Error('polliLib not loaded')));
+            const data = await (window.polliLib?.chat?.({ model, messages }) ?? Promise.reject(new Error('polliLib not loaded')));
             loadingDiv.remove();
 
             const messageObj = data?.choices?.[0]?.message || {};
@@ -654,14 +630,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 await processPatterns(window.imagePatterns || [], async prompt => {
                     if (!(window.polliLib && window.polliClient)) return;
                     try {
-                        const url = window.polliLib.mcp.generateImageUrl(window.polliClient, {
-                            prompt,
-                            width: 512,
-                            height: 512,
-                            private: true,
-                            nologo: true,
-                            safe: true
-                        });
+                        const url = window.polliLib.mcp.generateImageUrl(window.polliClient, { prompt });
                         imageUrls.push(url);
                     } catch (e) {
                         console.warn('polliLib generateImageUrl failed', e);

--- a/js/chat/chat-init.js
+++ b/js/chat/chat-init.js
@@ -214,15 +214,10 @@ document.addEventListener("DOMContentLoaded", () => {
             const i = parts.indexOf('prompt');
             if (i >= 0 && parts[i+1]) prompt = decodeURIComponent(parts[i+1]);
         } catch {}
-        const width = Number(urlObj.searchParams.get('width')) || img.naturalWidth || 512;
-        const height = Number(urlObj.searchParams.get('height')) || img.naturalHeight || 512;
-        const model = urlObj.searchParams.get('model') || (document.getElementById('model-select')?.value || undefined);
         let newUrl = img.src;
         try {
             if (window.polliLib && window.polliClient && prompt) {
-                newUrl = window.polliLib.mcp.generateImageUrl(window.polliClient, {
-                    prompt, width, height, seed: newSeed, nologo: true, model
-                });
+                newUrl = window.polliLib.mcp.generateImageUrl(window.polliClient, { prompt });
             } else {
                 urlObj.searchParams.set('seed', String(newSeed));
                 newUrl = urlObj.toString();
@@ -646,16 +641,9 @@ document.addEventListener("DOMContentLoaded", () => {
         }
         imagePrompt = imagePrompt.slice(0, 100) + ", photographic";
         const updateImage = () => {
-            const seed = randomSeed();
             try {
                 if (window.polliLib && window.polliClient) {
-                    const url = window.polliLib.mcp.generateImageUrl(window.polliClient, {
-                        prompt: imagePrompt,
-                        width: 512,
-                        height: 512,
-                        seed,
-                        nologo: true
-                    });
+                    const url = window.polliLib.mcp.generateImageUrl(window.polliClient, { prompt: imagePrompt });
                     voiceChatImage.src = url;
                 }
             } catch (e) {

--- a/js/chat/chat-storage.js
+++ b/js/chat/chat-storage.js
@@ -642,18 +642,11 @@ document.addEventListener("DOMContentLoaded", () => {
             imagePrompt = imagePrompt.substring(0, 100);
         }
         function updateImage() {
-            const seed = Math.floor(Math.random() * 1000000);
             const imageId = `voice-img-${Date.now()}`;
             localStorage.setItem(`voiceImageId_${imageId}`, imageId);
             try {
                 if (window.polliLib && window.polliClient) {
-                    const url = window.polliLib.mcp.generateImageUrl(window.polliClient, {
-                        prompt: imagePrompt,
-                        width: 512,
-                        height: 512,
-                        seed,
-                        nologo: true
-                    });
+                    const url = window.polliLib.mcp.generateImageUrl(window.polliClient, { prompt: imagePrompt });
                     voiceChatImage.src = url;
                 }
             } catch (e) {

--- a/js/chat/polli-utils.js
+++ b/js/chat/polli-utils.js
@@ -1,5 +1,5 @@
 (function(global){
-  function refreshPolliImage(url, options = {}) {
+  function refreshPolliImage(url) {
     if (!url) {
       return { error: 'No image source to refresh.' };
     }
@@ -23,15 +23,10 @@
       const i = parts.indexOf('prompt');
       if (i >= 0 && parts[i + 1]) prompt = decodeURIComponent(parts[i + 1]);
     } catch {}
-    const width = options.width || Number(urlObj.searchParams.get('width')) || 512;
-    const height = options.height || Number(urlObj.searchParams.get('height')) || 512;
-    const model = options.model || urlObj.searchParams.get('model') || (document.getElementById('model-select')?.value || undefined);
     let newUrl = url;
     try {
       if (global.polliLib && global.polliClient && prompt) {
-        newUrl = global.polliLib.mcp.generateImageUrl(global.polliClient, {
-          prompt, width, height, seed: newSeed, nologo: true, model
-        });
+        newUrl = global.polliLib.mcp.generateImageUrl(global.polliClient, { prompt });
       } else {
         urlObj.searchParams.set('seed', String(newSeed));
         newUrl = urlObj.toString();

--- a/js/ui/screensaver.js
+++ b/js/ui/screensaver.js
@@ -168,19 +168,6 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     fetchImageModels();
 
-    function generateSeed() {
-        return Math.floor(Math.random() * 1000000).toString().padStart(6, '0');
-    }
-
-    function getDimensions(aspect) {
-        switch (aspect) {
-            case "widescreen": return { width: 1920, height: 1080 };
-            case "square": return { width: 1024, height: 1024 };
-            case "portrait": return { width: 1080, height: 1920 };
-            default: return { width: 1920, height: 1080 };
-        }
-    }
-
     function preloadImage(url) {
         return new Promise((resolve, reject) => {
             const img = new Image();
@@ -208,7 +195,6 @@ document.addEventListener("DOMContentLoaded", () => {
     async function fetchDynamicPrompt() {
         const metaPrompt = "Generate exactly one short-125-character, new, fucked up and explicit wild image prompt as text only of outlandish and psychologically thrilling image. i.e. demented, evil, psychotic photo.";
         const textModel = document.getElementById("model-select")?.value;
-        const seed = generateSeed();
         try {
             const instructions = await ensureLocalInstructions();
             const messages = [];
@@ -219,7 +205,6 @@ document.addEventListener("DOMContentLoaded", () => {
             // Use polliLib chat to generate a single short prompt
             const data = await (window.polliLib?.chat?.({
                 model: textModel || "unity",
-                seed,
                 messages
             }) ?? Promise.reject(new Error('polliLib not loaded')));
             const generatedPrompt = data?.choices?.[0]?.message?.content?.trim();
@@ -270,23 +255,11 @@ document.addEventListener("DOMContentLoaded", () => {
             }
         }
 
-        const { width, height } = getDimensions(settings.aspect);
-        const seed = generateSeed();
-        const model = settings.model || modelSelect.value;
-        const enhance = settings.enhance;
-        const priv = settings.priv;
-
         // Build the image URL via polliLib MCP helper (no direct endpoint usage)
         const url = (function(){
             try {
                 if (window.polliLib && window.polliClient) {
-                    return window.polliLib.mcp.generateImageUrl(window.polliClient, {
-                        prompt,
-                        width, height, seed, model,
-                        nologo: true,
-                        private: priv,
-                        enhance: !!enhance
-                    });
+                    return window.polliLib.mcp.generateImageUrl(window.polliClient, { prompt });
                 }
                 console.warn("polliLib not loaded; using fallback URL");
             } catch (e) {


### PR DESCRIPTION
## Summary
- simplify PolliLib image URL generation across chat, storage, and screensaver modules to use only the prompt
- streamline text chat requests to send just model and messages

## Testing
- `npm test` *(fails: text(prompt) mentions apple — text output missing apple; vision identifies apple image — vision response missing apple)*

------
https://chatgpt.com/codex/tasks/task_b_68c6bac4bfdc83299173c0a7e3208088