### PR TITLE
Use prompt input for screensaver image URL

### DIFF
--- a/js/ui/screensaver.js
+++ b/js/ui/screensaver.js
@@ -234,11 +234,16 @@ document.addEventListener("DOMContentLoaded", () => {
 
         saveScreensaverSettings();
         let prompt = promptInput.value.trim();
-        if (!prompt || autoPromptEnabled) {
-            const success = await updatePrompt();
-            if (success) {
-                prompt = promptInput.value.trim();
-            } else if (!prompt) {
+        if (!prompt) {
+            if (autoPromptEnabled) {
+                const success = await updatePrompt();
+                if (success) {
+                    prompt = promptInput.value.trim();
+                } else {
+                    isTransitioning = false;
+                    return;
+                }
+            } else {
                 isTransitioning = false;
                 return;
             }


### PR DESCRIPTION
## Summary
- Ensure screensaver uses the user's prompt text before falling back to auto-prompting
- Generate Pollinations image URLs via polliLib using the selected prompt

## Testing
- `npm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c6c2865b608329bcdde3548ddf4bd1