### PR TITLE
test: verify pollilib request parameters

### DIFF
--- a/tests/pollilib-audio-request.mjs
+++ b/tests/pollilib-audio-request.mjs
@@ -1,0 +1,37 @@
+import assert from 'assert/strict';
+import { tts, stt } from '../js/polliLib/src/audio.js';
+import { PolliClientWeb } from '../js/polliLib/src/client.js';
+
+global.btoa = s => Buffer.from(s, 'binary').toString('base64');
+const calls = [];
+global.fetch = async (url, opts) => {
+  calls.push({ url: url.toString(), opts });
+  return {
+    ok: true,
+    blob: async () => new Blob(),
+    json: async () => ({ ok: true })
+  };
+};
+
+const client = new PolliClientWeb({ referrer: 'base.com', textBase: 'https://txt', imageBase: 'https://img' });
+
+// tts() request
+await tts('hello', { voice: 'alice', referrer: 'ref.com' }, client);
+let { url, opts } = calls[0];
+assert.equal(opts.method, 'GET');
+let u = new URL(url);
+assert.equal(u.searchParams.get('model'), 'openai-audio');
+assert.equal(u.searchParams.get('voice'), 'alice');
+assert.equal(u.searchParams.get('referrer'), 'ref.com');
+
+// stt() request
+const data = new Uint8Array([1,2,3]).buffer;
+await stt({ data, format: 'mp3' }, client);
+({ url, opts } = calls[1]);
+assert.equal(url, 'https://txt/openai');
+assert.equal(opts.method, 'POST');
+assert.equal(opts.headers['Content-Type'], 'application/json');
+const body = JSON.parse(opts.body);
+assert.equal(body.model, 'openai-audio');
+assert.equal(body.messages[0].content[1].input_audio.format, 'mp3');
+assert.equal(body.referrer, 'base.com');

--- a/tests/pollilib-text-request.mjs
+++ b/tests/pollilib-text-request.mjs
@@ -1,0 +1,54 @@
+import assert from 'assert/strict';
+import { text, chat } from '../js/polliLib/src/text.js';
+import { PolliClientWeb } from '../js/polliLib/src/client.js';
+
+const calls = [];
+global.fetch = async (url, opts) => {
+  calls.push({ url: url.toString(), opts });
+  return {
+    ok: true,
+    text: async () => 'ok',
+    json: async () => ({ ok: true })
+  };
+};
+
+const client = new PolliClientWeb({ referrer: 'default.com', textBase: 'https://txt', imageBase: 'https://img' });
+
+// text() request
+await text('hi there', {
+  model: 'foo',
+  temperature: 0.5,
+  seed: 1,
+  json: true,
+  private: true,
+  referrer: 'ref.com'
+}, client);
+
+let { url, opts } = calls[0];
+assert.equal(opts.method, 'GET');
+const u = new URL(url);
+assert.equal(u.origin + u.pathname, 'https://txt/hi%20there');
+assert.equal(u.searchParams.get('model'), 'foo');
+assert.equal(u.searchParams.get('temperature'), '0.5');
+assert.equal(u.searchParams.get('seed'), '1');
+assert.equal(u.searchParams.get('json'), 'true');
+assert.equal(u.searchParams.get('private'), 'true');
+assert.equal(u.searchParams.get('referrer'), 'ref.com');
+
+// chat() request
+await chat({
+  model: 'gpt',
+  messages: [{ role: 'user', content: 'hello' }],
+  temperature: 0.7
+}, client);
+
+({ url, opts } = calls[1]);
+assert.equal(url, 'https://txt/openai');
+assert.equal(opts.method, 'POST');
+assert.equal(opts.headers['Content-Type'], 'application/json');
+const body = JSON.parse(opts.body);
+assert.equal(body.model, 'gpt');
+assert.equal(body.temperature, 0.7);
+assert.equal(body.messages[0].content, 'hello');
+// default referrer added by client
+assert.equal(body.referrer, 'default.com');


### PR DESCRIPTION
## Summary
- add mocked tests for PolliLib text and chat requests, verifying method, parameter serialization, JSON usage, and referrer propagation
- add mocked audio tests to ensure tts and stt endpoints send correct headers and parameters

## Testing
- `node tests/run-all.mjs`


------
https://chatgpt.com/codex/tasks/task_b_68c734de41c0832f8cf70d5d9d4dc068