### PR TITLE
Avoid external dependency for site tests

### DIFF
--- a/js/marked.js
+++ b/js/marked.js
@@ -1,0 +1,48 @@
+export const marked = {
+  parse(markdown = '') {
+    const lines = markdown.split('\n');
+    let html = '';
+    let inCode = false;
+    let codeLines = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.startsWith('```')) {
+        if (inCode) {
+          html += `<pre><code>${escapeHtml(codeLines.join('\n'))}</code></pre>`;
+          inCode = false;
+          codeLines = [];
+        } else {
+          inCode = true;
+        }
+        continue;
+      }
+      if (inCode) {
+        codeLines.push(line);
+        continue;
+      }
+      if (line.trim() === '---') {
+        html += '<hr>';
+      } else if (line.trim()) {
+        html += `<p>${escapeHtml(line.trim())}</p>`;
+      }
+    }
+    if (inCode) {
+      html += `<pre><code>${escapeHtml(codeLines.join('\n'))}</code></pre>`;
+    }
+    return html;
+  }
+};
+
+function escapeHtml(str) {
+  return str.replace(/[&<>"']/g, ch => {
+    switch (ch) {
+      case '&': return '&amp;';
+      case '<': return '&lt;';
+      case '>': return '&gt;';
+      case '"': return '&quot;';
+      case "'": return '&#39;';
+      default: return ch;
+    }
+  });
+}
+

--- a/tests/site-ai-response.mjs
+++ b/tests/site-ai-response.mjs
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert';
-import { marked } from 'marked';
+import { marked } from '../js/marked.js';
 import { sanitizeMarkdown } from '../js/chat/markdown-sanitizer.js';
 import { PolliClientWeb } from '../js/polliLib/src/client.js';
 import { generateImageUrl } from '../js/polliLib/src/mcp.js';

--- a/tests/site-markdown-sanitization.mjs
+++ b/tests/site-markdown-sanitization.mjs
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert';
-import { marked } from 'marked';
+import { marked } from '../js/marked.js';
 import { sanitizeMarkdown } from '../js/chat/markdown-sanitizer.js';
 
 const input = [


### PR DESCRIPTION
## Summary
- Replace `marked` package usage in site tests with in-repo minimal markdown parser
- Implement simple markdown parser supporting code blocks and horizontal rules

## Testing
- `for f in tests/site-*.mjs; do echo Running $f; node "$f"; done`
- `set -e; for f in tests/pollilib-*.mjs; do echo Running $f; node "$f"; done`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c761923dfc832fa29c7ed4b668dc07