### PR TITLE
fix: initialize polliLib after load

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,56 +11,7 @@
     <link rel="stylesheet" href="js/ui/stylesScreensaver.css">
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script defer src="js/polliLib/polliLib-web.global.js"></script>
-    <script defer>
-      // Configure polliLib default client and expose an explicit client for MCP helpers
-      (function(){
-        try {
-          if (window.polliLib) {
-            // Derive base referrer from attribute or window location (no path segments)
-            const cur = document.currentScript;
-            const attrRef = cur && cur.getAttribute('data-referrer');
-            let base = window.location.origin;
-            if (attrRef) {
-              // Support values missing protocol by resolving against window.location.origin
-              try { base = new URL(attrRef, window.location.origin).origin; } catch {}
-            }
-            const referrer = base.endsWith('/') ? base : base + '/';
-            window.polliLib.configure({ referrer });
-            window.polliClient = window.polliLib.getDefaultClient();
-
-            // Provide basic helpers used by image features
-            if (!window.randomSeed) {
-              window.randomSeed = function randomSeed() { return Math.floor(Math.random() * 1000000); };
-            }
-            if (!window.imagePatterns) {
-              window.imagePatterns = [
-                { pattern: /```image\n([\s\S]*?)\n```/i, group: 1 },
-              ];
-            }
-            if (!window.audioPatterns) {
-              window.audioPatterns = [
-                { pattern: /```audio\n([\s\S]*?)\n```/i, group: 1 },
-              ];
-            }
-            if (!window.uiPatterns) {
-              window.uiPatterns = [
-                { pattern: /```ui\n([\s\S]*?)\n```/i, group: 1 },
-              ];
-            }
-            if (!window.voicePatterns) {
-              window.voicePatterns = [
-                { pattern: /```voice\n([\s\S]*?)\n```/i, group: 1 },
-              ];
-            }
-            if (!window.videoPatterns) {
-              window.videoPatterns = [
-                { pattern: /```video\n([\s\S]*?)\n```/i, group: 1 },
-              ];
-            }
-          }
-        } catch (e) { console.warn('polliLib configure failed', e); }
-      })();
-    </script>
+    <script defer src="js/pollilib-init.js"></script>
   </head>
   <body>
     <div id="screensaver-container" class="screensaver hidden">

--- a/js/pollilib-init.js
+++ b/js/pollilib-init.js
@@ -1,0 +1,48 @@
+// Configure polliLib default client and expose an explicit client for MCP helpers
+(function(){
+  try {
+    if (window.polliLib) {
+      // Derive base referrer from attribute or window location (no path segments)
+      const cur = document.currentScript;
+      const attrRef = cur && cur.getAttribute('data-referrer');
+      let base = window.location.origin;
+      if (attrRef) {
+        // Support values missing protocol by resolving against window.location.origin
+        try { base = new URL(attrRef, window.location.origin).origin; } catch {}
+      }
+      const referrer = base.endsWith('/') ? base : base + '/';
+      window.polliLib.configure({ referrer });
+      window.polliClient = window.polliLib.getDefaultClient();
+
+      // Provide basic helpers used by image features
+      if (!window.randomSeed) {
+        window.randomSeed = function randomSeed() { return Math.floor(Math.random() * 1000000); };
+      }
+      if (!window.imagePatterns) {
+        window.imagePatterns = [
+          { pattern: /```image\n([\s\S]*?)\n```/i, group: 1 },
+        ];
+      }
+      if (!window.audioPatterns) {
+        window.audioPatterns = [
+          { pattern: /```audio\n([\s\S]*?)\n```/i, group: 1 },
+        ];
+      }
+      if (!window.uiPatterns) {
+        window.uiPatterns = [
+          { pattern: /```ui\n([\s\S]*?)\n```/i, group: 1 },
+        ];
+      }
+      if (!window.voicePatterns) {
+        window.voicePatterns = [
+          { pattern: /```voice\n([\s\S]*?)\n```/i, group: 1 },
+        ];
+      }
+      if (!window.videoPatterns) {
+        window.videoPatterns = [
+          { pattern: /```video\n([\s\S]*?)\n```/i, group: 1 },
+        ];
+      }
+    }
+  } catch (e) { console.warn('polliLib configure failed', e); }
+})();


### PR DESCRIPTION
## Summary
- load polliLib configuration from a dedicated deferred script
- ensure polliClient and helpers are set up only after polliLib loads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c7be5fcb64832f8faca9f8bf73fe2c