### PR TITLE
Fix Pollinations auth and normalize generated image URLs

### DIFF
--- a/js/chat/chat-storage.js
+++ b/js/chat/chat-storage.js
@@ -1,5 +1,13 @@
 document.addEventListener("DOMContentLoaded", () => {
     const { chatBox, chatInput, clearChatBtn, voiceToggleBtn, modelSelect, synth, autoSpeakEnabled, speakMessage, stopSpeaking, showToast, toggleSpeechRecognition, initSpeechRecognition, handleVoiceCommand, speakSentences } = window._chatInternals;
+    const securePollinationsUrl = (url) => {
+        if (!url) return url;
+        try {
+            return window.ensurePollinationsUrlAuth ? window.ensurePollinationsUrlAuth(url) : url;
+        } catch {
+            return url;
+        }
+    };
     // Thumbnail gallery for main UI removed; retaining screensaver-only implementation
 
     function generateSessionTitle(messages) {
@@ -43,6 +51,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     function appendMessage({ role, content, index, imageUrls = [], audioUrls = [] }) {
+        const normalizedImages = Array.isArray(imageUrls) ? imageUrls.map(securePollinationsUrl) : [];
         const container = document.createElement("div");
         container.classList.add("message");
         container.dataset.index = index;
@@ -67,8 +76,8 @@ document.addEventListener("DOMContentLoaded", () => {
                 ? window.sanitizeMarkdown(content, window.blockedFenceTypes)
                 : content;
             bubbleContent.innerHTML = marked.parse(sanitized);
-            if (imageUrls.length > 0) {
-                imageUrls.forEach(url => {
+            if (normalizedImages.length > 0) {
+                normalizedImages.forEach(url => {
                     const imageContainer = createImageElement(url);
                     bubbleContent.appendChild(imageContainer);
                 });
@@ -187,7 +196,8 @@ document.addEventListener("DOMContentLoaded", () => {
         img.alt = "AI Generated Image";
         img.className = "ai-generated-image";
         img.style.display = "none";
-        img.dataset.imageUrl = url;
+        const normalizedUrl = securePollinationsUrl(url);
+        img.dataset.imageUrl = normalizedUrl;
         img.dataset.imageId = imageId;
         img.crossOrigin = "anonymous";
         imageContainer.appendChild(img);
@@ -198,7 +208,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const loadViaPolli = async () => {
             try {
-                const u = new URL(url);
+                const targetUrl = normalizedUrl || url;
+                const u = new URL(targetUrl);
                 const parts = u.pathname.split('/');
                 const i = parts.indexOf('prompt');
                 const prompt = i >= 0 && parts[i + 1] ? decodeURIComponent(parts[i + 1]) : '';
@@ -207,14 +218,14 @@ document.addEventListener("DOMContentLoaded", () => {
                 const height = u.searchParams.get('height') ? Number(u.searchParams.get('height')) : undefined;
                 if (window.polliLib && window.polliClient && prompt) {
                     const data = await window.polliLib.image(prompt, { model, width, height, json: true }, window.polliClient);
-                    const src = data?.url ? data.url : URL.createObjectURL(data);
+                    const src = data?.url ? securePollinationsUrl(data.url) : URL.createObjectURL(data);
                     img.src = src;
                 } else {
-                    img.src = url;
+                    img.src = normalizedUrl || url;
                 }
             } catch (e) {
                 console.warn('polliLib image failed', e);
-                img.src = url;
+                img.src = normalizedUrl || url;
             }
         };
 
@@ -410,7 +421,7 @@ document.addEventListener("DOMContentLoaded", () => {
         chatBox.innerHTML = "";
         messages.forEach((msg, idx) => {
             console.log(`Appending message at index ${idx}: ${msg.role}`);
-            const storedImages = Array.isArray(msg.imageUrls) ? msg.imageUrls : [];
+            const storedImages = Array.isArray(msg.imageUrls) ? msg.imageUrls.map(securePollinationsUrl) : [];
             const storedAudio = Array.isArray(msg.audioUrls) ? msg.audioUrls : [];
             let imgMatches = storedImages;
             if (imgMatches.length === 0 && msg.content) {
@@ -418,7 +429,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     const baseList = [ window.polliClient.imageBase ];
                     const escaped = baseList.map(b => b.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
                     const imgRegex = new RegExp(`(${escaped.join('|')})/prompt/[^ ]+`, 'g');
-                    imgMatches = msg.content.match(imgRegex) || [];
+                    imgMatches = (msg.content.match(imgRegex) || []).map(securePollinationsUrl);
                 } else {
                     imgMatches = [];
                 }
@@ -437,17 +448,19 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     window.addNewMessage = function ({ role, content, imageUrls = [], audioUrls = [], metadata = null }) {
         const currentSession = Storage.getCurrentSession();
-        currentSession.messages.push({ role, content, imageUrls, audioUrls, metadata });
+        const normalizedImages = Array.isArray(imageUrls) ? imageUrls.map(securePollinationsUrl) : [];
+        currentSession.messages.push({ role, content, imageUrls: normalizedImages, audioUrls, metadata });
         Storage.updateSessionMessages(currentSession.id, currentSession.messages);
         if (!window.polliClient || !window.polliClient.imageBase) {
-            appendMessage({ role, content, index: currentSession.messages.length - 1, imageUrls, audioUrls });
+            appendMessage({ role, content, index: currentSession.messages.length - 1, imageUrls: normalizedImages, audioUrls });
             if (role === "ai") checkAndUpdateSessionTitle();
             return;
         }
         const base = window.polliClient.imageBase;
         const escaped = base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         const imgRegex = new RegExp(`(${escaped}\/prompt\/[^ ]+)`, 'g');
-        const imgMatches = imageUrls.length > 0 ? imageUrls : (content.match(imgRegex) || []);
+        const imgMatchesRaw = normalizedImages.length > 0 ? normalizedImages : (content.match(imgRegex) || []);
+        const imgMatches = imgMatchesRaw.map(securePollinationsUrl);
         appendMessage({
             role,
             content,

--- a/js/chat/polli-utils.js
+++ b/js/chat/polli-utils.js
@@ -45,7 +45,11 @@
     if (!newUrlObj.searchParams.has('referrer') && global.polliClient?.referrer) {
       newUrlObj.searchParams.set('referrer', global.polliClient.referrer);
     }
-    return { url: newUrlObj.toString() };
+    let final = newUrlObj.toString();
+    if (typeof global.ensurePollinationsUrlAuth === 'function') {
+      final = global.ensurePollinationsUrlAuth(final);
+    }
+    return { url: final };
   }
   global.refreshPolliImage = refreshPolliImage;
 })(window);

--- a/js/pollilib-init.js
+++ b/js/pollilib-init.js
@@ -12,7 +12,117 @@
       }
       const referrer = base.endsWith('/') ? base : base + '/';
       window.polliLib.configure({ referrer });
-      window.polliClient = window.polliLib.getDefaultClient();
+
+      const defaultClient = typeof window.polliLib.getDefaultClient === 'function'
+        ? window.polliLib.getDefaultClient()
+        : new window.polliLib.PolliClientWeb({ referrer });
+
+      const token = typeof window !== 'undefined'
+        ? (window.POLLINATIONS_TOKEN || null)
+        : null;
+
+      const pollinationsOrigins = new Set();
+      const maybeAddOrigin = (value) => {
+        if (!value) return;
+        try {
+          const origin = new URL(value, window.location.origin).origin;
+          pollinationsOrigins.add(origin);
+        } catch {}
+      };
+
+      maybeAddOrigin(defaultClient?.imageBase);
+      maybeAddOrigin(defaultClient?.textBase);
+
+      const ensureAuthHeaders = (headers = {}) => {
+        if (!token) return headers;
+        const next = { ...headers };
+        if (!next.Authorization) next.Authorization = `Bearer ${token}`;
+        return next;
+      };
+
+      const shouldAugment = (url) => {
+        if (!url) return false;
+        try {
+          const target = new URL(url, window.location.origin);
+          return pollinationsOrigins.has(target.origin);
+        } catch {
+          return false;
+        }
+      };
+
+      const ensureUrlAuth = (url) => {
+        if (!url || (!token && !referrer)) return url;
+        if (!shouldAugment(url)) return url;
+        try {
+          const target = new URL(url);
+          if (referrer && !target.searchParams.has('referrer')) {
+            target.searchParams.set('referrer', referrer);
+          }
+          if (token && !target.searchParams.has('token')) {
+            target.searchParams.set('token', token);
+          }
+          return target.toString();
+        } catch {
+          return url;
+        }
+      };
+
+      if (defaultClient && token) {
+        const originalGet = defaultClient.get?.bind(defaultClient);
+        if (originalGet) {
+          defaultClient.get = async function patchedGet(url, options = {}) {
+            if (!shouldAugment(url)) {
+              return originalGet(url, options);
+            }
+            const nextOptions = { ...options };
+            nextOptions.headers = ensureAuthHeaders(options.headers);
+            const params = { ...(options.params || {}) };
+            if (token && params.token == null) params.token = token;
+            nextOptions.params = params;
+            return originalGet(url, nextOptions);
+          };
+        }
+        const originalPostJson = defaultClient.postJson?.bind(defaultClient);
+        if (originalPostJson) {
+          defaultClient.postJson = async function patchedPostJson(url, body, options = {}) {
+            if (!shouldAugment(url)) {
+              return originalPostJson(url, body, options);
+            }
+            const payload = { ...(body || {}) };
+            if (token && payload.token == null) payload.token = token;
+            const nextOptions = { ...options };
+            nextOptions.headers = ensureAuthHeaders(options.headers);
+            return originalPostJson(url, payload, nextOptions);
+          };
+        }
+      }
+
+      if (typeof window.polliLib.image === 'function') {
+        const originalImage = window.polliLib.image.bind(window.polliLib);
+        window.polliLib.image = async function patchedImage(prompt, opts, client) {
+          const result = await originalImage(prompt, opts, client);
+          if (result && typeof result === 'object' && !('arrayBuffer' in result)) {
+            if ('url' in result && result.url) {
+              result.url = ensureUrlAuth(result.url);
+            }
+          }
+          return result;
+        };
+      }
+
+      if (window.polliLib?.mcp?.generateImageUrl) {
+        const originalGenerateImageUrl = window.polliLib.mcp.generateImageUrl.bind(window.polliLib.mcp);
+        window.polliLib.mcp.generateImageUrl = function patchedGenerateImageUrl(client, params = {}) {
+          const payload = { ...(params || {}) };
+          if (token && payload.token == null) payload.token = token;
+          if (referrer && payload.referrer == null) payload.referrer = referrer;
+          const rawUrl = originalGenerateImageUrl(client || defaultClient, payload);
+          return ensureUrlAuth(rawUrl);
+        };
+      }
+
+      window.polliClient = defaultClient;
+      window.ensurePollinationsUrlAuth = ensureUrlAuth;
 
       // Provide basic helpers used by image features
       if (!window.randomSeed) {


### PR DESCRIPTION
## Summary
- extend the Pollinations bootstrap to honor the injected token/referrer, patch client helpers, and expose a URL normalizer
- request JSON metadata for AI-generated images and store normalized Pollinations URLs across chat and storage flows
- update simple mode rendering and the image refresh helper to reuse authenticated Pollinations links

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c8e2887240832991b248165eea9ec2