### PR TITLE
Align chat requests with Pollinations tool calling flow

### DIFF
--- a/tests/pollilib-capability-usage.mjs
+++ b/tests/pollilib-capability-usage.mjs
@@ -26,15 +26,16 @@ function buildOptions(model) {
   const opts = { model, messages: [] };
   if (caps.text?.[model]?.tools) {
     opts.tools = ['toolA'];
-    opts.json = true;
+    opts.response_format = { type: 'json_object' };
   }
   return opts;
 }
 
 const withTools = buildOptions('bar');
-assert('tools' in withTools && withTools.json === true);
+assert('tools' in withTools);
+assert.deepEqual(withTools.response_format, { type: 'json_object' });
 const withoutTools = buildOptions('baz');
 assert(!('tools' in withoutTools));
-assert(!('json' in withoutTools));
+assert(!('response_format' in withoutTools));
 
 console.log('capability-usage test passed');


### PR DESCRIPTION
## Summary
- add helpers to construct chat payloads with `response_format` and orchestrate tool call loops using the polliLib client
- update the chat send routine to reuse the helpers, forward tool outputs back to the API, and surface executed tool results in the UI
- teach the capability usage test to expect `response_format` instead of the legacy `json` flag

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c8f14693948329828abd2a9850cbf4